### PR TITLE
Fix formatting of SSL feature description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Customize your setup via environment variables in the `.env` file.
 - Self-hosted **n8n** automation platform.
 - **Postgres** as database backend.
 - **Redis** for queue mode.
-- Automatic SSL (Traefik or similar).
+- Automatic SSL (Traefik or similar ...).
 - **SMTP** for email notifications.
 - Flexible webhook and runner configuration.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Adjust the Automatic SSL list item to include an ellipsis in the README.md